### PR TITLE
Introduce a delay to matrix_init_user when OLEDs enabled to resolve a race condition between keyboard init and the OLED init

### DIFF
--- a/keyboards/sol/keymaps/default/keymap.c
+++ b/keyboards/sol/keymaps/default/keymap.c
@@ -5,7 +5,10 @@
 #include "split_util.h"
 #endif
 #ifdef SSD1306OLED
+  #include "wait.h"
   #include "common/ssd1306.h"
+
+  #define STARTUP_DELAY 1750
 #endif
 
 extern keymap_config_t keymap_config;
@@ -253,6 +256,7 @@ void matrix_init_user(void) {
     #endif
     //SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
     #ifdef SSD1306OLED
+        wait_ms(STARTUP_DELAY);      // wait until keyboard init done
         iota_gfx_init(!has_usb());   // turns on the display
     #endif
 }
@@ -284,6 +288,7 @@ void matrix_update(struct CharacterMatrix *dest,
 #define L_BASE 0
 #define L_FN (1<<_FN)
 #define L_ADJ (1<<_ADJ)
+#define L_ADJ_TRI (L_ADJ|L_FN)
 
 static void render_logo(struct CharacterMatrix *matrix) {
 

--- a/keyboards/sol/keymaps/default/rules.mk
+++ b/keyboards/sol/keymaps/default/rules.mk
@@ -18,7 +18,6 @@ RGBLIGHT_FULL_POWER = yes   # Allow maximum RGB brightness. Otherwise, limited t
 UNICODE_ENABLE = no         # Unicode
 SWAP_HANDS_ENABLE = no      # Enable one-hand typing
 ENCODER_ENABLE_CUSTOM = yes # Enable rotary encoder (+90)
-RGBLIGHT_FULL_POWER = no    # Allow maximum RGB brightness. Otherwise, limited to a safe level for a normal USB-A port
 UNICODE_ENABLE = no         # Unicode
 SWAP_HANDS_ENABLE = no      # Enable one-hand typing
 ENCODER_ENABLE_CUSTOM = yes # Enable rotary encoder (+90)


### PR DESCRIPTION
## Description

While building the Sol keyboard with OLEDs I ran into an issue with the OLEDs working fine immediately after flashing the keyboard with OLEDs enabled, but not initializing properly when unplugging and plugging the keyboard on a computer.

Turns out it's a race condition issue with the rest of the keyboard init and the OLED init. If the iota_gfx_init() method call gets called before another part of the keyboard init code hasn't finished yet, the OLEDs will not properly initialize and remain blank. Introducing a delay before calling iota_gfx_init() resolves this issue.

A slightly better way of fixing this would be to somehow check whether the conflicting initialization was completed and only calling iota_gfx_init() call after that.

Also added a L_ADJ_TRI definition to fix a compilation error when OLEDs are enabled with #define SSD1306OLED.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Core
- [ ] Bugfix
- [ ] New Feature
- [ ] Enhancement/Optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/Layout/Userspace (addition or update)
- [ ] Documentation

Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. (https://docs.qmk.fm/#/contributing)
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
